### PR TITLE
Improve fps throttling

### DIFF
--- a/core/src/com/ericc/the/game/MainGame.java
+++ b/core/src/com/ericc/the/game/MainGame.java
@@ -8,10 +8,10 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.FillViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.ericc.the.game.components.FieldOfViewComponent;
-import com.ericc.the.game.components.ScreenBoundariesComponent;
 import com.ericc.the.game.entities.Mob;
 import com.ericc.the.game.entities.Player;
 import com.ericc.the.game.entities.Screen;
+import com.ericc.the.game.helpers.FpsThrottle;
 import com.ericc.the.game.map.Generator;
 import com.ericc.the.game.map.Map;
 import com.ericc.the.game.systems.logic.AiSystem;
@@ -38,6 +38,8 @@ public class MainGame extends Game {
 
     public final static boolean DEBUG = true; ///< turns the debug mode on and off
     private final static boolean MUSIC = false; ///< turns the music on and off
+
+    private FpsThrottle fpsThrottle = new FpsThrottle(60);
 
     @Override
     public void create() {
@@ -90,13 +92,7 @@ public class MainGame extends Game {
         centerCamera();
 
         engines.updateRealtimeEngine();
-
-        // TODO: Make FPS cap more resistant against extreme framerate drops
-        try {
-            Thread.sleep(16);
-        } catch(Exception e) {
-            System.out.print("Unexpected sleep interruption\n");
-        }
+        fpsThrottle.sleepToNextFrame();
 
         System.out.print(Gdx.graphics.getFramesPerSecond() + "\n");
     }

--- a/core/src/com/ericc/the/game/helpers/FpsThrottle.java
+++ b/core/src/com/ericc/the/game/helpers/FpsThrottle.java
@@ -1,0 +1,29 @@
+package com.ericc.the.game.helpers;
+
+import com.badlogic.gdx.utils.TimeUtils;
+
+public class FpsThrottle {
+    private long frameTimeMs;
+    private long nextFrameTimestamp;
+
+    public FpsThrottle(int fps) {
+        frameTimeMs = 1000/fps + 1;
+        nextFrameTimestamp = TimeUtils.millis() + frameTimeMs;
+    }
+
+    public void sleepToNextFrame() {
+        long currentTimeMs = TimeUtils.millis();
+
+        if (currentTimeMs < nextFrameTimestamp) {
+            try {
+                System.out.println(nextFrameTimestamp - currentTimeMs);
+                Thread.sleep(nextFrameTimestamp - currentTimeMs);
+            } catch (InterruptedException e) {
+                System.err.println("Unexpected interruption of fps throttling sleep");
+            }
+            nextFrameTimestamp += frameTimeMs;
+        } else {
+            nextFrameTimestamp = currentTimeMs + frameTimeMs;
+        }
+    }
+}


### PR DESCRIPTION
The previous solution was incorrect, because it didn't account for
the time spent rendering a frame. This caused artificial stuttering
on weaker machines.